### PR TITLE
Fix key creation error handling

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -91,7 +91,9 @@ func loadOrCreateKey() (crypto.PrivKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	os.WriteFile(keyFile, data, 0600)
+	if err := os.WriteFile(keyFile, data, 0600); err != nil {
+		return nil, err
+	}
 	return privKey, nil
 }
 


### PR DESCRIPTION
## Summary
- handle errors from `os.WriteFile` when creating the server's key

## Testing
- `go test ./...` *(fails: Forbidden to download Go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_684430c7820c832b8396c71a18aba513