### PR TITLE
Fix peer registration when no addresses known

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -114,6 +114,13 @@ func onPeerConnected(net network.Network, conn network.Conn, h host.Host) {
 		time.Sleep(time.Second)
 	}
 
+	// Если адресов все ещё нет, используем адрес из соединения
+	if len(addrs) == 0 {
+		if maddr := conn.RemoteMultiaddr(); maddr != nil {
+			addrs = []ma.Multiaddr{maddr}
+		}
+	}
+
 	if len(addrs) == 0 {
 		fmt.Println("⚠️ У пира нет известных адресов, он не будет добавлен:", peerID)
 		return


### PR DESCRIPTION
## Summary
- fallback to remote connection address if peer addresses missing

## Testing
- `go build ./cmd/...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68517a950a08832bbc60a260e014fb89