### PR TITLE
Fix connection resets for result stream

### DIFF
--- a/cmd/p2p_node/main.go
+++ b/cmd/p2p_node/main.go
@@ -70,7 +70,7 @@ func main() {
 	// Если режим processor, регистрируем обработчики для приема стиля и изображений
 	if mode == "processor" {
 		h.SetStreamHandler("/receive-style/1.0.0", p2p.HandleReceiveStyle)
-		h.SetStreamHandler("/receive-image/1.0.0", p2p.HandleReceiveImage)
+		h.SetStreamHandler("/receive-image/1.0.0", p2p.MakeReceiveImageHandler(h))
 		fmt.Println("🔧 Режим процессора: обработчики для /receive-style/1.0.0 и /receive-image/1.0.0 зарегистрированы.")
 		// Режим процессора работает только для обработки входящих данных
 		select {}

--- a/internal/p2p/receive.go
+++ b/internal/p2p/receive.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	host "github.com/libp2p/go-libp2p/core/host"
 	network "github.com/libp2p/go-libp2p/core/network"
 	ma "github.com/multiformats/go-multiaddr"
 )
@@ -75,58 +76,60 @@ func HandleReceiveStyle(s network.Stream) {
 }
 
 // Обработчик получения изображения для стилизации по протоколу "/receive-image/1.0.0"
-func HandleReceiveImage(s network.Stream) {
-	defer s.Close()
-	// Оборачиваем поток в bufio.Reader
-	reader := bufio.NewReader(s)
-	// Читаем заголовок (ожидается "IMAGE")
-	header, err := reader.ReadString('\n')
-	if err != nil {
-		log.Println("❌ Ошибка чтения заголовка:", err)
-		return
-	}
-	header = strings.TrimSpace(header)
-	if header != "IMAGE" {
-		log.Println("❌ Неверный заголовок, ожидается IMAGE, получено:", header)
-		return
-	}
+func MakeReceiveImageHandler(h host.Host) network.StreamHandler {
+	return func(s network.Stream) {
+		defer s.Close()
+		// Оборачиваем поток в bufio.Reader
+		reader := bufio.NewReader(s)
+		// Читаем заголовок (ожидается "IMAGE")
+		header, err := reader.ReadString('\n')
+		if err != nil {
+			log.Println("❌ Ошибка чтения заголовка:", err)
+			return
+		}
+		header = strings.TrimSpace(header)
+		if header != "IMAGE" {
+			log.Println("❌ Неверный заголовок, ожидается IMAGE, получено:", header)
+			return
+		}
 
-	// Сохраняем оставшиеся данные в файл, создавая уникальное имя в папке "received_images"
-	dir := "received_images"
-	os.MkdirAll(dir, 0755)
-	tmpIn := fmt.Sprintf("%s/received_%d.jpg", dir, time.Now().UnixNano())
-	err = SaveReaderToFile(reader, tmpIn)
-	if err != nil {
-		log.Println("❌ Ошибка сохранения полученного изображения:", err)
-		return
-	}
-	fmt.Println("📥 Изображение получено:", tmpIn)
+		// Сохраняем оставшиеся данные в файл, создавая уникальное имя в папке "received_images"
+		dir := "received_images"
+		os.MkdirAll(dir, 0755)
+		tmpIn := fmt.Sprintf("%s/received_%d.jpg", dir, time.Now().UnixNano())
+		err = SaveReaderToFile(reader, tmpIn)
+		if err != nil {
+			log.Println("❌ Ошибка сохранения полученного изображения:", err)
+			return
+		}
+		fmt.Println("📥 Изображение получено:", tmpIn)
 
-	// Запускаем стилизацию с использованием локального styleFile
-	dirOut := "processed_images"
-	os.MkdirAll(dirOut, 0755)
-	tmpOut := fmt.Sprintf("%s/styled_%d.jpg", dirOut, time.Now().UnixNano())
-	// Сохраняем путь к адресам
-	addrs := []ma.Multiaddr{s.Conn().RemoteMultiaddr()}
+		// Запускаем стилизацию с использованием локального styleFile
+		dirOut := "processed_images"
+		os.MkdirAll(dirOut, 0755)
+		tmpOut := fmt.Sprintf("%s/styled_%d.jpg", dirOut, time.Now().UnixNano())
+		// Сохраняем путь к адресам
+		addrs := []ma.Multiaddr{s.Conn().RemoteMultiaddr()}
 
-	cmd := exec.Command(style.GetPythonCommand(), "style_transfer.py", "stylize", tmpIn, styleFile, tmpOut)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	fmt.Println("⏳ Запуск стилизации для", tmpIn)
-	if err := cmd.Run(); err != nil {
-		log.Println("❌ Ошибка стилизации:", err)
-		SendProcessedImage(s.Conn().RemotePeer(), addrs, "", true, "Ошибка стилизации изображения")
+		cmd := exec.Command(style.GetPythonCommand(), "style_transfer.py", "stylize", tmpIn, styleFile, tmpOut)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		fmt.Println("⏳ Запуск стилизации для", tmpIn)
+		if err := cmd.Run(); err != nil {
+			log.Println("❌ Ошибка стилизации:", err)
+			SendProcessedImage(h, s.Conn().RemotePeer(), addrs, "", true, "Ошибка стилизации изображения")
+			os.Remove(tmpIn)
+			return
+		}
+		fmt.Println("🖼 Стилизация завершена:", tmpOut)
+
+		// Отправляем результат
+		SendProcessedImage(h, s.Conn().RemotePeer(), addrs, tmpOut, false, "")
+
+		// Удаляем временные файлы
 		os.Remove(tmpIn)
-		return
+		os.Remove(tmpOut)
 	}
-	fmt.Println("🖼 Стилизация завершена:", tmpOut)
-
-	// Отправляем результат
-	SendProcessedImage(s.Conn().RemotePeer(), addrs, tmpOut, false, "")
-
-	// Удаляем временные файлы
-	os.Remove(tmpIn)
-	os.Remove(tmpOut)
 }
 
 // SaveStreamToFile читает весь поток и сохраняет его в указанный файл.

--- a/internal/p2p/send.go
+++ b/internal/p2p/send.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/libp2p/go-libp2p"
 	peerstore "github.com/libp2p/go-libp2p/core/peer"
 	ma "github.com/multiformats/go-multiaddr"
 
@@ -71,19 +70,11 @@ func SendImage(h host.Host, receiver peerstore.AddrInfo, imagePath string) {
 }
 
 // Функция отправки обработанного изображения обратно отправителю (в режиме процессора)
-func SendProcessedImage(receiver peerstore.ID, addrs []ma.Multiaddr, filePath string, failed bool, errMsg string) {
-	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
-	if err != nil {
-		log.Println("❌ Ошибка создания временного хоста:", err)
-		return
-	}
-	defer h.Close()
-
+func SendProcessedImage(h host.Host, receiver peerstore.ID, addrs []ma.Multiaddr, filePath string, failed bool, errMsg string) {
 	receiverInfo := peerstore.AddrInfo{ID: receiver, Addrs: addrs}
 	h.Peerstore().AddAddrs(receiverInfo.ID, receiverInfo.Addrs, time.Minute)
 
-	err = h.Connect(context.Background(), receiverInfo)
-	if err != nil {
+	if err := h.Connect(context.Background(), receiverInfo); err != nil {
 		log.Println("❌ Ошибка подключения к получателю:", err)
 		return
 	}


### PR DESCRIPTION
## Summary
- remove ephemeral host creation when sending processed images
- add handler factory to capture host for sending results
- use the new handler in the P2P node

## Testing
- `pip install -r requirements.txt`
- `go build ./cmd/p2p_node` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68517c60d3f0832b810aebd13600ad8e