### PR TITLE
Implement token accounting and result reporting

### DIFF
--- a/internal/p2p/report.go
+++ b/internal/p2p/report.go
@@ -1,0 +1,30 @@
+package p2p
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	host "github.com/libp2p/go-libp2p/core/host"
+	peerstore "github.com/libp2p/go-libp2p/core/peer"
+)
+
+// ReportResult отправляет на сервер информацию об успешной или неуспешной
+// обработке изображения. ok=true означает успех.
+func ReportResult(h host.Host, server peerstore.AddrInfo, processor peerstore.ID, ok bool) {
+	stream, err := h.NewStream(context.Background(), server.ID, "/report-result/1.0.0")
+	if err != nil {
+		log.Println("❌ Ошибка подключения для отправки отчета:", err)
+		return
+	}
+	defer stream.Close()
+
+	status := "FAIL"
+	if ok {
+		status = "OK"
+	}
+	msg := fmt.Sprintf("%s|%s", processor.String(), status)
+	if _, err := stream.Write([]byte(msg)); err != nil {
+		log.Println("❌ Ошибка отправки отчета:", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add token checks and deductions in `handlePeerRequest`
- add `handleResultReport` for processing success/failure notifications
- report processor results from initiators
- support `NO_TOKENS` response in peer requests

## Testing
- `go build ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68568932c6e0832ba00c9126a4ba897a