### PR TITLE
Fix docker network address for bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ received_images/
 received_styles/
 test.txt
 style.pt
+weights/*
+!weights/.gitkeep
 *_key.pem

--- a/README.md
+++ b/README.md
@@ -9,4 +9,6 @@ weights will be loaded from disk instead of being downloaded.
 
 When using `docker-compose`, place the weights file at `weights/vgg19-dcbb9e9d.pth`
 in the project root. The compose configuration mounts this path and sets
-`VGG_WEIGHTS` automatically for all nodes.
+`VGG_WEIGHTS` automatically for all nodes. If `VGG_WEIGHTS` is set but the file
+is missing, the program will fail instead of attempting to download the
+weights.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ The style transfer script relies on VGG19 weights. If the environment has no
 internet access, set the `VGG_WEIGHTS` environment variable to the path of a
 pre-downloaded `vgg19-dcbb9e9d.pth` file. When this variable is provided, the
 weights will be loaded from disk instead of being downloaded.
+
+When using `docker-compose`, place the weights file at `weights/vgg19-dcbb9e9d.pth`
+in the project root. The compose configuration mounts this path and sets
+`VGG_WEIGHTS` automatically for all nodes.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # coursework_mimapr
+
+## Offline weights
+
+The style transfer script relies on VGG19 weights. If the environment has no
+internet access, set the `VGG_WEIGHTS` environment variable to the path of a
+pre-downloaded `vgg19-dcbb9e9d.pth` file. When this variable is provided, the
+weights will be loaded from disk instead of being downloaded.

--- a/cmd/p2p_node/main.go
+++ b/cmd/p2p_node/main.go
@@ -78,9 +78,19 @@ func main() {
 	if err != nil {
 		log.Fatal("❌ Ошибка преобразования в PeerInfo:", err)
 	}
-	err = h.Connect(context.Background(), *bootstrapInfo)
-	if err != nil {
-		log.Fatal("❌ Ошибка подключения к серверу:", err)
+
+	// Пытаемся подключиться несколько раз, ожидая готовности сервера
+	var connectErr error
+	for i := 0; i < 10; i++ {
+		connectErr = h.Connect(context.Background(), *bootstrapInfo)
+		if connectErr == nil {
+			break
+		}
+		log.Println("🔄 Ожидание сервера, попытка", i+1)
+		time.Sleep(2 * time.Second)
+	}
+	if connectErr != nil {
+		log.Fatal("❌ Ошибка подключения к серверу:", connectErr)
 	}
 	fmt.Println("✅ Подключен к серверу:", bootstrapInfo.ID)
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -9,8 +9,9 @@ import (
 	"time"
 
 	p2p "coursework_mimapr/internal/p2p"
+
 	libp2p "github.com/libp2p/go-libp2p"
-	crypto "github.com/libp2p/go-libp2p/core/crypto"
+
 	host "github.com/libp2p/go-libp2p/core/host"
 	network "github.com/libp2p/go-libp2p/core/network"
 	peer "github.com/libp2p/go-libp2p/core/peer"

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -57,6 +57,7 @@ func main() {
 	if hostName == "" {
 		hostName = "localhost"
 	}
+	fmt.Println("🛰 Используется bootstrap host:", hostName)
 	bootstrapLine := fmt.Sprintf("/dns4/%s/tcp/9000/p2p/%s\n",
 		hostName, h.ID().String(),
 	)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - "9000:9000"
     volumes:
       - ./bootstrap.txt:/app/bootstrap.txt:write
+    environment:
+      - BOOTSTRAP_HOST=bootstrap-server
 
   initiator:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       args:
         BUILD_SERVICE: cmd/server
     container_name: bootstrap-server
+    hostname: bootstrap-server
     networks:
       - coursework-net
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,10 @@ services:
       - ./style_image:/app/style_image:ro
       - ./test_images:/app/test_images:ro
       - ./bootstrap.txt:/app/bootstrap.txt:ro
+      - ./weights:/app/weights:ro
     environment:
       - MODE=initiator
+      - VGG_WEIGHTS=/app/weights/vgg19-dcbb9e9d.pth
     # Оверрайдим entrypoint так, чтобы сразу подставить два ответа через stdin:
     # "printf '%s\n%s\n' '/app/style_image/Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg' '/app/test_images' | /usr/local/bin/app initiator"
     entrypoint: ["/bin/sh", "-c", 
@@ -52,9 +54,11 @@ services:
       - coursework-net
     volumes:
       - ./bootstrap.txt:/app/bootstrap.txt:ro
+      - ./weights:/app/weights:ro
     environment:
       - EPOCHS=300
       - MODE=processor
+      - VGG_WEIGHTS=/app/weights/vgg19-dcbb9e9d.pth
     command: ["processor"]
 
   processor2:
@@ -70,9 +74,11 @@ services:
       - coursework-net
     volumes:
       - ./bootstrap.txt:/app/bootstrap.txt:ro
+      - ./weights:/app/weights:ro
     environment:
       - EPOCHS=300
       - MODE=processor
+      - VGG_WEIGHTS=/app/weights/vgg19-dcbb9e9d.pth
     command: ["processor"]
 
   processor3:
@@ -88,9 +94,11 @@ services:
       - coursework-net
     volumes:
       - ./bootstrap.txt:/app/bootstrap.txt:ro
+      - ./weights:/app/weights:ro
     environment:
       - EPOCHS=300
       - MODE=processor
+      - VGG_WEIGHTS=/app/weights/vgg19-dcbb9e9d.pth
     command: ["processor"]
 
 networks:

--- a/style_transfer.py
+++ b/style_transfer.py
@@ -31,7 +31,17 @@ class VGG(nn.Module):
     def __init__(self):
         super(VGG, self).__init__()
         self.req_features = ['0', '5', '10', '19', '28']
-        self.model = vgg19(weights=VGG19_Weights.DEFAULT).features[:29]
+        weights_path = os.environ.get("VGG_WEIGHTS")
+        if weights_path and os.path.exists(weights_path):
+            print(f"🔍 Загрузка весов VGG19 из {weights_path}")
+            base = vgg19(weights=None)
+            state = torch.load(weights_path, map_location=device)
+            base.load_state_dict(state)
+        else:
+            if weights_path:
+                print(f"⚠️ Файл весов не найден: {weights_path}. Пытаемся скачивать из torchvision")
+            base = vgg19(weights=VGG19_Weights.DEFAULT)
+        self.model = base.features[:29]
 
 
     def forward(self, x):

--- a/style_transfer.py
+++ b/style_transfer.py
@@ -32,14 +32,16 @@ class VGG(nn.Module):
         super(VGG, self).__init__()
         self.req_features = ['0', '5', '10', '19', '28']
         weights_path = os.environ.get("VGG_WEIGHTS")
-        if weights_path and os.path.exists(weights_path):
-            print(f"🔍 Загрузка весов VGG19 из {weights_path}")
-            base = vgg19(weights=None)
-            state = torch.load(weights_path, map_location=device)
-            base.load_state_dict(state)
+        if weights_path:
+            if os.path.exists(weights_path):
+                print(f"🔍 Загрузка весов VGG19 из {weights_path}")
+                base = vgg19(weights=None)
+                state = torch.load(weights_path, map_location=device)
+                base.load_state_dict(state)
+            else:
+                raise FileNotFoundError(f"VGG_WEIGHTS указан, но файл не найден: {weights_path}")
         else:
-            if weights_path:
-                print(f"⚠️ Файл весов не найден: {weights_path}. Пытаемся скачивать из torchvision")
+            print("⚠️ VGG_WEIGHTS не задан, пробуем скачать веса из torchvision (может не работать офлайн)")
             base = vgg19(weights=VGG19_Weights.DEFAULT)
         self.model = base.features[:29]
 


### PR DESCRIPTION
## Summary
- ensure p2p nodes read a valid bootstrap address by setting `BOOTSTRAP_HOST` in docker-compose

## Testing
- `gofmt -w cmd/server/server.go cmd/p2p_node/main.go internal/p2p/*.go`


------
https://chatgpt.com/codex/tasks/task_e_685849865bbc832b91d0bdc09f85490d